### PR TITLE
Check that the proxy is not blank

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,7 @@ import (
 )
 
 func NewClient(clientHello utls.ClientHelloID, proxyUrl ...string) (http.Client, error) {
-	if len(proxyUrl) > 0 && len(proxyUrl) > 0 {
+	if len(proxyUrl) > 0 && len(proxyUrl[0]) > 0 {
 		dialer, err := newConnectDialer(proxyUrl[0])
 		if err != nil {
 			return http.Client{}, err


### PR DESCRIPTION
Fixed an incorrect check for a blank string that you added in https://github.com/x04/cclient/issues/3. You added another `len(proxyUrl) > 0`:

```go
if len(proxyUrl) > 0 && len(proxyUrl) > 0 {
```

I think what you meant is to check if the first proxy is not a blank string.